### PR TITLE
Fix for shipping validator handling of null configuration

### DIFF
--- a/Model/Quote/ShippingMethodValidator.php
+++ b/Model/Quote/ShippingMethodValidator.php
@@ -44,7 +44,9 @@ class ShippingMethodValidator
      */
     public function isValid($methodCode)
     {
-        $disabledShippingMethods = explode(',', $this->config->getValue('disallowed_shipping_methods'));
+        $disabledShippingMethods = array_filter(
+            explode(',', $this->config->getValue('disallowed_shipping_methods'))
+        );
         return !in_array($methodCode, $disabledShippingMethods);
     }
 }


### PR DESCRIPTION
If no shipping methods have been configured as disallowed, the original code here yields `$disallowedShippingMethods` like this:
```
[ 
    "",
]
```
If you go to checkout and have multiple shipping methods available and no pre-select configured, your `$methodCode` is going to be `null`. The validation then becomes this:
```
!in_array(null, [""])
```
which evaluates to false, as `null == ""`, and vipps will disable itself as a payment method until a shipping choice is made, at which point vipps will reveal itself.

This patch fixes that.