### PR TITLE
Fixed failed place order by Vipps: On Klarna init and on callback

### DIFF
--- a/Controller/Payment/Klarna/InitRegular.php
+++ b/Controller/Payment/Klarna/InitRegular.php
@@ -218,7 +218,7 @@ class InitRegular implements ActionInterface
 
         $this->setCheckoutMethod($quote);
 
-        $maskedQuoteId = $this->quoteIdToMaskedQuoteId->execute($quote->getId());
+        $maskedQuoteId = $this->quoteIdToMaskedQuoteId->execute((int)$quote->getId());
         switch ($quote->getCheckoutMethod()) {
             case Onepage::METHOD_CUSTOMER:
                 $this->paymentInformationManagement->savePaymentInformationAndPlaceOrder(

--- a/Model/QuoteRepository.php
+++ b/Model/QuoteRepository.php
@@ -158,7 +158,7 @@ class QuoteRepository implements QuoteRepositoryInterface
     }
 
     /**
-     * @param int $vippsQuoteId
+     * @param int $monitoringQuoteId
      *
      * @return Quote
      * @throws NoSuchEntityException
@@ -166,6 +166,7 @@ class QuoteRepository implements QuoteRepositoryInterface
     public function load(int $monitoringQuoteId)
     {
         $monitoringQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($monitoringQuote, $monitoringQuoteId);
 
         if (!$monitoringQuote->getId()) {
             throw NoSuchEntityException::singleField('entity_id', $monitoringQuoteId);


### PR DESCRIPTION
Hi!

**Pre-conditions**
Magento 2.4.1
Klarna Checkout 9.1.5.
Vipps Payment 2.4.6
PHP 7.4

**Issues**
1. After choose Vipps in Klarna iframe Customer redirects to Cart page with error "An error occurred during request to Vipps. Please try again later. " . It's related with load quote and id is get as string. 
2. After fix pt.1, Vipps is initialized fine and after confirm , Customer redirected to checkout/onepage/failure page with message "Ingen slik enhet med entity_id = 11", but after checking vipps_quote - entity is present.

**Fixes**
1. Added cast to int for quote id, because it's desired type.
2. Related with removed loading and method load always get exception, because $monitoringQuote->getId() is empty in Vipps\Payment\Model\QuoteRepository.

Issue 1 is relevant for 2.3.x versions and I've added PR #89.

Please review,   