### PR TITLE
Fix order creation issues for logged-in customer

### DIFF
--- a/Controller/Payment/InitExpress.php
+++ b/Controller/Payment/InitExpress.php
@@ -190,7 +190,7 @@ class InitExpress implements ActionInterface
             ]
         );
 
-        if (!$quote->getCheckoutMethod()) {
+        if (!$quote->getCheckoutMethod(true)) {
             if ($this->customerSession->isLoggedIn()) {
                 $quote->setCheckoutMethod(Onepage::METHOD_CUSTOMER);
             } elseif ($this->checkoutHelper->isAllowedGuestCheckout($quote)) {

--- a/Controller/Payment/Klarna/InitRegular.php
+++ b/Controller/Payment/Klarna/InitRegular.php
@@ -221,10 +221,10 @@ class InitRegular implements ActionInterface
         $this->setCheckoutMethod($quote);
 
         $maskedQuoteId = $this->quoteIdToMaskedQuoteId->execute((int)$quote->getId());
-        switch ($quote->getCheckoutMethod()) {
+        switch ($quote->getCheckoutMethod(true)) {
             case Onepage::METHOD_CUSTOMER:
                 $this->paymentInformationManagement->savePaymentInformationAndPlaceOrder(
-                    $maskedQuoteId,
+                    $quote->getId(),
                     $quote->getPayment()
                 );
                 break;
@@ -246,7 +246,7 @@ class InitRegular implements ActionInterface
      */
     private function setCheckoutMethod(Quote $quote)
     {
-        if (!$quote->getCheckoutMethod()) {
+        if (!$quote->getCheckoutMethod(true)) {
             if ($this->customerSession->isLoggedIn()) {
                 $quote->setCheckoutMethod(Onepage::METHOD_CUSTOMER);
             } elseif ($this->checkoutHelper->isAllowedGuestCheckout($quote)) {


### PR DESCRIPTION
We met with the issue in the Magento VIPPS payment module. It's not possible to place VIPPS order through Klarna Checkout if customer is logged in to Magento. The correct behavior is to create Magento order BEFORE the customer is redirected to Vipps payment page. But there is an issue in the code which prevents order creation for Magento logged-in customers, and the order for such customers is created only AFTER payment is done when the customer is redirected back to Magento.

Problem is in 2 places and it exists in the latest module version:
1. `$quote->getCheckoutMethod()` function needs `true` argument in `\Vipps\Payment\Controller\Payment\Klarna\InitRegular::placeOrder(quote)`, `\Vipps\Payment\Controller\Payment\Klarna\InitRegular::setCheckoutMethod(quote)` and `\Vipps\Payment\Controller\Payment\InitExpress::initiatePayment()`. Vipps module recognizes "customer", "guest" and "register" checkout methods. But for logged-in customer:
`$quote->getCheckoutMethod() = 'login_in';`
when 
`$quote->getCheckoutMethod(true) = 'customer';`
(see `\Magento\Quote\Model\Quote::getCheckoutMethod(originalMethod)`).
 
2. `$this->paymentInformationManagement->savePaymentInformationAndPlaceOrder()` for "customer" needs `$quoteId`, not `$maskedQuoteId` in `\Vipps\Payment\Controller\Payment\Klarna\InitRegular::placeOrder(quote)`. 