### PR TITLE
Fixed syntax error causing error on compile

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -30,7 +30,7 @@ class Config extends OriginConfig
 
     public function __construct(
         ScopeConfigInterface  $scopeConfig,
-        StoreManagerInterface $storeManager,
+        StoreManagerInterface $storeManager
     ) {
         parent::__construct($scopeConfig, Vipps::METHOD_CODE);
 

--- a/GatewayEpayment/Validator/ReferenceValidator.php
+++ b/GatewayEpayment/Validator/ReferenceValidator.php
@@ -50,7 +50,7 @@ class ReferenceValidator extends AbstractValidator
         SubjectReader $subjectReader,
         QuoteFactory $quoteFactory,
         Quote $quoteResource,
-        OrderFactory $orderFactory,
+        OrderFactory $orderFactory
     ) {
         parent::__construct($resultFactory);
         $this->subjectReader = $subjectReader;


### PR DESCRIPTION
Resolved a syntax error causing an issue during the execution of the `bin/magento setup:di:compile` command.