### PR TITLE
VIPPS-464: Fix various issues in latest version

### DIFF
--- a/Controller/Payment/Klarna/InitRegular.php
+++ b/Controller/Payment/Klarna/InitRegular.php
@@ -2,16 +2,17 @@
 /**
  * Copyright 2020 Vipps
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
- * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
- * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
- * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON
+ * INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 declare(strict_types=1);
 
@@ -176,7 +177,7 @@ class InitRegular implements ActionInterface
             $this->placeOrder($quote);
 
             $this->checkoutSession->clearStorage();
-            $response->setUrl($responseData['url']);
+            $response->setUrl($responseData['url'] ?? $responseData['redirectUrl'] ?? '');
         } catch (LocalizedException $e) {
             $this->logger->critical($this->enlargeMessage($e));
             $this->messageManager->addErrorMessage($e->getMessage());

--- a/GatewayEpayment/Validator/CancelTransactionValidator.php
+++ b/GatewayEpayment/Validator/CancelTransactionValidator.php
@@ -13,7 +13,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-namespace Vipps\Payment\Gateway\Validator;
+namespace Vipps\Payment\GatewayEpayment\Validator;
 
 use Magento\Payment\Gateway\Validator\AbstractValidator;
 use Magento\Payment\Gateway\Validator\ResultInterface;

--- a/GatewayEpayment/Validator/CaptureTransactionValidator.php
+++ b/GatewayEpayment/Validator/CaptureTransactionValidator.php
@@ -13,7 +13,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-namespace Vipps\Payment\Gateway\Validator;
+namespace Vipps\Payment\GatewayEpayment\Validator;
 
 use Magento\Payment\Gateway\Validator\AbstractValidator;
 use Magento\Payment\Gateway\Validator\ResultInterface;

--- a/GatewayEpayment/Validator/RefundTransactionValidator.php
+++ b/GatewayEpayment/Validator/RefundTransactionValidator.php
@@ -13,7 +13,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-namespace Vipps\Payment\Gateway\Validator;
+namespace Vipps\Payment\GatewayEpayment\Validator;
 
 use Magento\Payment\Gateway\Validator\AbstractValidator;
 use Magento\Payment\Gateway\Validator\ResultInterface;

--- a/Model/Fallback/Authorise/Commerce.php
+++ b/Model/Fallback/Authorise/Commerce.php
@@ -11,11 +11,13 @@ use Vipps\Payment\Api\Fallback\AuthoriseInterface;
 
 class Commerce implements AuthoriseInterface
 {
+    /**
+     * @inheritDoc
+     */
     public function do(RequestInterface $request, QuoteInterface $vippsQuote): void
     {
-        if (!$request->getParam('order_id') ||
-            !$request->getParam('auth_token')
-        ) {
+        $orderId = $this->getOrderId($request);
+        if (!$orderId || !$request->getParam('auth_token')) {
             throw new LocalizedException(__('Invalid request parameters'));
         }
 
@@ -24,8 +26,16 @@ class Commerce implements AuthoriseInterface
         }
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getOrderId(RequestInterface $request): string
     {
-        return $request->getParam('order_id');
+        $orderId = (string) $request->getParam('order_id');
+        if (!$orderId) {
+            $orderId = (string) $request->getParam('reference');
+        }
+
+        return $orderId;
     }
 }

--- a/Model/Fallback/Authorise/Commerce.php
+++ b/Model/Fallback/Authorise/Commerce.php
@@ -11,13 +11,11 @@ use Vipps\Payment\Api\Fallback\AuthoriseInterface;
 
 class Commerce implements AuthoriseInterface
 {
-    /**
-     * @inheritDoc
-     */
     public function do(RequestInterface $request, QuoteInterface $vippsQuote): void
     {
-        $orderId = $this->getOrderId($request);
-        if (!$orderId || !$request->getParam('auth_token')) {
+        if (!$request->getParam('order_id') ||
+            !$request->getParam('auth_token')
+        ) {
             throw new LocalizedException(__('Invalid request parameters'));
         }
 
@@ -26,16 +24,8 @@ class Commerce implements AuthoriseInterface
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getOrderId(RequestInterface $request): string
     {
-        $orderId = (string) $request->getParam('order_id');
-        if (!$orderId) {
-            $orderId = (string) $request->getParam('reference');
-        }
-
-        return $orderId;
+        return $request->getParam('order_id');
     }
 }

--- a/Model/TokenProvider.php
+++ b/Model/TokenProvider.php
@@ -184,6 +184,7 @@ class TokenProvider implements TokenProviderInterface
                 'Content-Type: application/json',
                 'Content-Length: 0'
             ];
+
             // send request
             $adapter->write('POST', $this->urlResolver->getUrl(self::$endpointUrl), '1.1', $headers);
             $response = Response::fromString($adapter->read());
@@ -196,7 +197,7 @@ class TokenProvider implements TokenProviderInterface
             }
         } catch (\Exception $e) {    //@codingStandardsIgnoreLine
             $this->logger->critical($e->getMessage());
-            throw new AuthenticationException((string)__('Can\'t retrieve access token from %1.', $this->config->getTitle()), $e);
+            throw new AuthenticationException(__('Can\'t retrieve access token from %1.', $this->config->getTitle()), $e);
         } finally {
             $adapter ? $adapter->close() : null;
         }

--- a/Model/Transaction/StatusVisitor.php
+++ b/Model/Transaction/StatusVisitor.php
@@ -44,6 +44,8 @@ class StatusVisitor
         if ($transaction instanceof Payment) {
             return $transaction->isAborter();
         }
+
+        return false;
     }
 
     public function isAuthorised($transaction): bool

--- a/Test/Integration/Controller/Payment/Klarna/InitRegularTest.php
+++ b/Test/Integration/Controller/Payment/Klarna/InitRegularTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Copyright 2020 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON
+ * INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Vipps\Payment\Test\Integration\Model;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\HTTP\Adapter\Curl;
+use Magento\Framework\HTTP\Adapter\CurlFactory;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;
+use Magento\TestFramework\TestCase\AbstractController;
+use PHPUnit\Framework\MockObject\MockObject;
+use Vipps\Payment\GatewayEpayment\Http\Client\PaymentCurl;
+use Vipps\Payment\Model\TokenProvider;
+
+class InitRegularTest extends AbstractController
+{
+    /**
+     * @var Curl|MockObject
+     */
+    private $paymentCurlMock;
+
+    /**
+     * @var Curl|MockObject
+     */
+    private $tokenProviderCurlMock;
+
+    /**
+     * @var Session
+     */
+    private $checkoutSession;
+
+    /**
+     * @var QuoteResource
+     */
+    private $quoteResource;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tokenProviderCurlMock = $this->createMock(Curl::class);
+        $adapterFactoryMock = $this->createMock(CurlFactory::class);
+        $adapterFactoryMock->expects($this->any())->method('create')->willReturn($this->tokenProviderCurlMock);
+        $tokenProvider = $this->_objectManager->create(TokenProvider::class, [
+            'adapterFactory' => $adapterFactoryMock,
+        ]);
+        $this->_objectManager->addSharedInstance($tokenProvider, TokenProvider::class);
+
+        $this->paymentCurlMock = $this->createMock(Curl::class);
+        $adapterFactoryMock = $this->createMock(CurlFactory::class);
+        $adapterFactoryMock->expects($this->any())->method('create')->willReturn($this->paymentCurlMock);
+        $paymentCurl = $this->_objectManager->create(PaymentCurl::class, [
+            'adapterFactory' => $adapterFactoryMock,
+        ]);
+        $this->_objectManager->addSharedInstance($paymentCurl, PaymentCurl::class);
+
+        $this->checkoutSession = $this->_objectManager->get(Session::class);
+        $this->_objectManager->addSharedInstance($this->checkoutSession, Session::class);
+        $this->quoteResource = $this->_objectManager->create(QuoteResource::class);
+        $this->productRepository = $this->_objectManager->create(ProductRepositoryInterface::class);
+    }
+
+    /**
+     * @magentoAppArea frontend
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation enabled
+     * @magentoConfigFixture current_store payment/klarna_kco/active 1
+     * @magentoDataFixture Magento/Catalog/_files/products.php
+     */
+    public function testExecuteShouldSuccessfullyExecuteWithoutErrors()
+    {
+        $quote = $this->prepareQuote();
+
+        /** @var Quote\Payment $payment */
+        $payment = $this->_objectManager->create(Quote\Payment::class);
+        $payment->setMethod('klarna_kco');
+        $payment->setQuote($quote);
+        $payment->save();
+
+        $this->tokenProviderCurlMock->expects($this->any())->method('read')->willReturn(
+            "HTTP/1.1 200 Success\n\n"
+            . \json_encode([
+                'token_type' => 'Bearer',
+                'expires_in' => '3599',
+                'ext_expires_in' => 0,
+                'not_before' => \time() + 10000,
+                'resource' => '00000003-0000-0000-c000-000000000000',
+                'access_token' => 'token1234',
+            ])
+        );
+
+        $orderId = $this->quoteResource->getReservedOrderId($quote) + 1;
+        $orderId = \str_pad($orderId, 9, '0', STR_PAD_LEFT);
+
+        $this->paymentCurlMock->expects($this->any())->method('read')->willReturn(
+            "HTTP/1.1 200 Success\n\n"
+            . \json_encode([
+                'reference' => $orderId,
+                'redirectUrl' => 'url/to/redirect/to',
+            ])
+        );
+
+        $this->checkoutSession->replaceQuote($quote);
+
+        $this->dispatch('vipps/payment/klarna_initRegular');
+        $this->assertSessionMessages($this->equalTo([]));
+    }
+
+    /**
+     * @return Quote
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function prepareQuote(): Quote
+    {
+        $product = $this->productRepository->get('simple');
+
+        /** @var Quote $quote */
+        $quote = $this->_objectManager->create(Quote::class);
+        $quote->setCustomerEmail('customer@example.com');
+        $quote->setStoreId(1);
+        $quote->addProduct($product);
+
+        $shippingAddress = $quote->getShippingAddress();
+        $shippingAddress->setFirstname('John');
+        $shippingAddress->setLastname('Doe');
+        $shippingAddress->setStreet('Street');
+        $shippingAddress->setCity('City');
+        $shippingAddress->setPostcode(1234);
+        $shippingAddress->setCountryId('NO');
+        $shippingAddress->setTelephone('04012345');
+        $shippingAddress->setShippingMethod('flatrate_flatrate');
+        $quote->setShippingAddress($shippingAddress);
+
+        $billingAddress = $quote->getBillingAddress();
+        $billingAddress->setFirstname('John');
+        $billingAddress->setLastname('Doe');
+        $billingAddress->setStreet('Street');
+        $billingAddress->setCity('City');
+        $billingAddress->setPostcode(1234);
+        $billingAddress->setCountryId('NO');
+        $billingAddress->setTelephone('04012345');
+        $quote->setBillingAddress($billingAddress);
+
+        $quote->save();
+
+        return $quote;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -36,6 +36,18 @@
         </arguments>
     </type>
 
+    <virtualType name="ProxyEpaymentCommandManager" type="Vipps\Payment\GatewayEpayment\Command\PaymentCommandManager">
+        <arguments>
+            <argument xsi:type="object" name="commandManager">ProxyCommandManager</argument>
+        </arguments>
+    </virtualType>
+
+    <type name="Vipps\Payment\Controller\Payment\Klarna\InitRegular">
+        <arguments>
+            <argument xsi:type="object" name="commandManager">ProxyEpaymentCommandManager</argument>
+        </arguments>
+    </type>
+
     <type name="Vipps\Payment\Model\CommandPoolProxy">
         <arguments>
             <argument xsi:type="object" name="configVersionPool">versionedCommandPool</argument>


### PR DESCRIPTION
Following pull request primarily fixes following issues:

- In `vipps/module-payment/Controller/Payment/Klarna/InitRegular.php`, a crash would happen due to missing array key `url` in the payment initiation response. In reality the array key is supposed to be `redirectUrl`. Fixed the issue by supporting both array keys.
- Fixed issue where `vipps/module-payment/Controller/Payment/Klarna/InitRegular.php` would not respect the configuration `Stores / Configuration / Sales / Payment Methods / Vipps / Basic Settings / Api Version` and instead executed always as if the setting was set to Mobile Pay. This would cause some issues since some logic executes based on the admin setting, but other the controller executes with Mobile Pay logic.

Additionally, while investigating the two other issues, added also following fixes:

- Fixed some invalid namespaces under `GatewayEpayment/Validator` folder as these would crash if anything is referencing them.
- In `vipps/module-payment/Controller/Payment/Fallback.php` improved detection of cancelled payment. Cancelling payment in Vipps can cause also transaction state ABORTED, but this was not handled as cancellation, which resulted in the last quote not getting restored to user session.
- Fixed some error handling issues in `vipps/module-payment/Model/TokenProvider.php` where incompatible string was passed to exception instance and caused the error handling to fail further


Added also integration tests to replicate and confirm some of these fixes. These are not running automatically anywhere.