### PR TITLE
Fix Monolog v3 compatibility for Magento 2.4.8

### DIFF
--- a/Model/Logger/Handler/Debug.php
+++ b/Model/Logger/Handler/Debug.php
@@ -60,11 +60,11 @@ class Debug extends Base
     /**
      * {@inheritdoc}
      *
-     * @param array $record
+     * @param \Monolog\LogRecord|array $record
      *
      * @return bool
      */
-    public function isHandling(array $record): bool
+    public function isHandling(\Monolog\LogRecord|array $record): bool
     {
         if ($this->config && (bool)$this->config->getValue('debug')) {
             return parent::isHandling($record);


### PR DESCRIPTION
## Problem
Running `bin/magento setup:upgrade` on Magento 2.4.8 throws a fatal PHP error:

    PHP Fatal error: Declaration of Vipps\Payment\Model\Logger\Handler\Debug::isHandling(array $record): bool
    must be compatible with Monolog\Handler\AbstractHandler::isHandling(Monolog\LogRecord $record): bool
    in .../Model/Logger/Handler/Debug.php on line 67

Monolog v3 (shipped with Magento 2.4.8) changed the `isHandling()` signature
from `array $record` to `Monolog\LogRecord $record`, making the module completely
unusable — even `bin/magento module:disable` fails.

## Fix
Updated `isHandling()` parameter type in `Model/Logger/Handler/Debug.php`
to accept `\Monolog\LogRecord|array $record`, compatible with both Monolog v2 and v3.

## Tested on
Magento 2.4.8-p4 with Monolog v3