### PR TITLE
Fix grammar in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you want to contribute: Great! No issue or pull request is too small!
 
 ## Contributing
 
-Contributing is easy. The steps below is intended to be helpful. Please help us improve it.
+Contributing is easy. The steps below are intended to be helpful. Please help us improve it.
 
 1. Create a personal fork of the project on GitHub from [vipps-magento](https://github.com/vippsas/vipps-magento)
 1. Clone the fork on your local machine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you want to contribute: Great! No issue or pull request is too small!
 
 ## Contributing
 
-Contributing is easy. The steps below are intended to be helpful. Please help us improve it.
+Contributing is easy. The below steps are intended to be helpful. Please help us improve it.
 
 1. Create a personal fork of the project on GitHub from [vipps-magento](https://github.com/vippsas/vipps-magento)
 1. Clone the fork on your local machine

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,7 +46,7 @@ Otherwise, the refund should be finished first. This Vipps/MobilePay Payment mod
 
 ## How do I refund an order?
 
-For orders refunding Adobe Commerce proposes [Adobe Commerce: Credit Memo](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/order-management/credit-memos/credit-memos) functionality.
+For orders refunding Adobe Commerce, we propose [Adobe Commerce: Credit Memo](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/order-management/credit-memos/credit-memos) functionality.
 Credit Memo allows you to make a refund for captured transaction.
 
 ## How do I partially refund an order?
@@ -75,8 +75,8 @@ Failure to set it up properly means it will not function as expected.
 
 ## Why are some orders missing in Adobe Commerce?
 
-This scenario is possible for express payment flow. Unlike a regular payment, order is not created before redirecting to
-Vipps Landing page. If the transaction was successfully initiated by client, a new record
+It is possible for some orders to be missing when using the Express payment flow because, unlike a regular payment, the order is not created before redirecting to
+Vipps MobilePay Landing page. If the transaction was successfully initiated by client, a new record
 with a quote ID and reserved order ID will be created in DB table `vipps_quote`. This can be helpful to find a status of a transaction.
 
 ## How do I enable Vipps Payment for Klarna Checkout

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,7 +46,7 @@ Otherwise, the refund should be finished first. This Vipps/MobilePay Payment mod
 
 ## How do I refund an order?
 
-For orders refunding Adobe Commerce propose [Adobe Commerce: Credit Memo](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/order-management/credit-memos/credit-memos) functionality.
+For orders refunding Adobe Commerce proposes [Adobe Commerce: Credit Memo](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/order-management/credit-memos/credit-memos) functionality.
 Credit Memo allows you to make a refund for captured transaction.
 
 ## How do I partially refund an order?
@@ -75,7 +75,7 @@ Failure to set it up properly means it will not function as expected.
 
 ## Why are some orders missing in Adobe Commerce?
 
-This scenario is possible for express payment flow. Unlike of regular payment, order is not created before redirecting to
+This scenario is possible for express payment flow. Unlike a regular payment, order is not created before redirecting to
 Vipps Landing page. If the transaction was successfully initiated by client, a new record
 with a quote ID and reserved order ID will be created in DB table `vipps_quote`. This can be helpful to find a status of a transaction.
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -148,13 +148,13 @@ You can find this page under the *System* > *Vipps Payment* > *Quote Processing*
 1. When an order is cancelled on the Vipps MobilePay side, Adobe Commerce marks such record as `Cancelled`.
    * The order is cancelled on the Adobe Commerce side, if it was previously placed.
 
-1. If an order has not been accepted on the Vipps MobilePay side within some period of time, it marked as expired. Adobe Commerce subsequently marks the order as `Expired`.
+1. If an order has not been accepted on the Vipps MobilePay side within some period of time, it is marked as expired. Adobe Commerce subsequently marks the order as `Expired`.
    * The order is cancelled on the Adobe Commerce side, if it was previously placed.
 
 1. If an order has not been yet been accepted on the Vipps MobilePay side and has not yet expired, Adobe Commerce marks it as `Processing`. An appropriate message is added on *Record details* page.
-1. If an order has been accepted on the Vipps MobilePay side, but an error has occurred during order placement on Adobe Commerce side, such record marks as `Processing`. An appropriate message is added on record details page.
+1. If an order has been accepted on the Vipps MobilePay side, but an error has occurred during order placement on Adobe Commerce side, such a record is marked as `Processing`. An appropriate message is added on record details page.
 1. Adobe Commerce will attempt to process a record three times. After it fails three times, the record is marked as `Place Failed`.
-1. It is possible to specify that Adobe Commerce must cancel a Vipps MobilePay order automatically when an appropriate Adobe Commerce quote has failed, so that client's money released. See *Store* > *Sales* > *Payment Methods* > *Vipps MobilePay* > *Cancellation*.
+1. It is possible to specify that Adobe Commerce must cancel a Vipps MobilePay order automatically when an appropriate Adobe Commerce quote has failed, so that client's money is released. See *Store* > *Sales* > *Payment Methods* > *Vipps MobilePay* > *Cancellation*.
 1. If it is specified that Adobe Commerce must cancel all failed quotes, then Adobe Commerce fetches all records marked as `Place Failed`, cancels them, and marks them as `Cancelled`.
 
 Here is a diagram of the process:
@@ -178,7 +178,7 @@ Monitoring quote statuses include:
 * *Placement Failed* - All attempts were unsuccessful.
 * *Canceled* - The payment has been cancelled.
   Cancellation can be initiated by the customer in Vipps MobilePay or manually/automatically by *Adobe Commerce for Quotes* in *Placement Failed* status.
-* *Cancel Failed* - The payment could not be cancelled. Record in this status and require admin/developer interaction.
+* *Cancel Failed* - The payment could not be cancelled. Records in this status require admin/developer interaction.
 
 ## Enable debug mode / requests profiling
 


### PR DESCRIPTION
Conservative grammar fixes across CONTRIBUTING.md, docs/FAQ.md, and docs/documentation.md: subject-verb agreement errors, missing verbs, wrong prepositions, and a missing article. No functional content changed.