### PR TITLE
VIPPS-61: restore cart on back from Vipps/MobilePay Express payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [3.0.2] - 2026-06-15
+
+### Fixed
+- Prevent the cart from being emptied when returning to the store via the browser back button after
+  starting a Vipps/MobilePay Express payment. The pending quote id is stored in a cookie when express
+  payment is initiated and the cart is restored from it on return (VIPPS-61).
+
 ## [3.0.1] - 2026-06-15
 
 ### Added

--- a/Controller/Payment/Fallback.php
+++ b/Controller/Payment/Fallback.php
@@ -40,6 +40,7 @@ use Vipps\Payment\Api\Data\QuoteInterface;
 use Vipps\Payment\Api\QuoteRepositoryInterface;
 use Vipps\Payment\GatewayEpayment\Config\Config;
 use Vipps\Payment\GatewayEpayment\Data\Payment;
+use Vipps\Payment\Model\Express\CartRestoreCookie;
 use Vipps\Payment\Model\Fallback\AuthoriseProxy;
 use Vipps\Payment\Model\Gdpr\Compliance;
 use Vipps\Payment\Model\OrderLocator;
@@ -126,6 +127,11 @@ class Fallback implements ActionInterface, CsrfAwareActionInterface
     private AuthoriseProxy $authoriseProxy;
 
     /**
+     * @var CartRestoreCookie
+     */
+    private $cartRestoreCookie;
+
+    /**
      * Fallback constructor.
      *
      * @param ResultFactory $resultFactory
@@ -157,7 +163,8 @@ class Fallback implements ActionInterface, CsrfAwareActionInterface
         LoggerInterface          $logger,
         Config                   $config,
         StatusVisitor            $statusVisitor,
-        AuthoriseProxy           $authoriseProxy
+        AuthoriseProxy           $authoriseProxy,
+        CartRestoreCookie        $cartRestoreCookie
     ) {
         $this->resultFactory = $resultFactory;
         $this->request = $request;
@@ -173,6 +180,7 @@ class Fallback implements ActionInterface, CsrfAwareActionInterface
         $this->config = $config;
         $this->statusVisitor = $statusVisitor;
         $this->authoriseProxy = $authoriseProxy;
+        $this->cartRestoreCookie = $cartRestoreCookie;
     }
 
     /**
@@ -226,6 +234,7 @@ class Fallback implements ActionInterface, CsrfAwareActionInterface
                     $resultRedirect->setPath('checkout/cart', ['_secure' => true]);
                 }
             }
+            $this->cartRestoreCookie->clearPending();
             $this->logger->debug($this->request->getRequestString());
         }
 

--- a/Controller/Payment/InitExpress.php
+++ b/Controller/Payment/InitExpress.php
@@ -34,6 +34,7 @@ use Psr\Log\LoggerInterface;
 use Vipps\Payment\Api\CommandManagerInterface;
 use Vipps\Payment\GatewayEpayment\Config\Config;
 use Vipps\Payment\GatewayEpayment\Request\InitSession\InitiateBuilderInterface;
+use Vipps\Payment\Model\Express\CartRestoreCookie;
 use Vipps\Payment\Model\Method\Vipps;
 
 /**
@@ -94,6 +95,11 @@ class InitExpress implements ActionInterface
     private $logger;
 
     /**
+     * @var CartRestoreCookie
+     */
+    private $cartRestoreCookie;
+
+    /**
      * InitExpress constructor.
      *
      * @param ResultFactory $resultFactory
@@ -106,6 +112,7 @@ class InitExpress implements ActionInterface
      * @param ManagerInterface $messageManager
      * @param CheckoutHelper $checkoutHelper
      * @param LoggerInterface $logger
+     * @param CartRestoreCookie $cartRestoreCookie
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -119,7 +126,8 @@ class InitExpress implements ActionInterface
         Config $config,
         ManagerInterface $messageManager,
         CheckoutHelper $checkoutHelper,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        CartRestoreCookie $cartRestoreCookie
     ) {
         $this->resultFactory = $resultFactory;
         $this->checkoutSession = $checkoutSession;
@@ -131,6 +139,7 @@ class InitExpress implements ActionInterface
         $this->messageManager = $messageManager;
         $this->checkoutHelper = $checkoutHelper;
         $this->logger = $logger;
+        $this->cartRestoreCookie = $cartRestoreCookie;
     }
 
     public function execute()
@@ -144,6 +153,11 @@ class InitExpress implements ActionInterface
             }
 
             $responseData = $this->initiatePayment();
+
+            $quoteId = $this->checkoutSession->getQuoteId();
+            if ($quoteId) {
+                $this->cartRestoreCookie->setPending((int)$quoteId);
+            }
 
             $this->checkoutSession->clearStorage();
             $resultRedirect->setPath($responseData['redirectUrl'], ['_secure' => true]);

--- a/Controller/Payment/RestoreCart.php
+++ b/Controller/Payment/RestoreCart.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2026 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Vipps\Payment\Controller\Payment;
+
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Vipps\Payment\Model\Express\CartRestorer;
+use Vipps\Payment\Model\Express\CartRestoreCookie;
+
+class RestoreCart implements ActionInterface, CsrfAwareActionInterface
+{
+    public function __construct(
+        private readonly ResultFactory $resultFactory,
+        private readonly CartRestoreCookie $cartRestoreCookie,
+        private readonly CartRestorer $cartRestorer
+    ) {
+    }
+
+    public function execute()
+    {
+        $result = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+
+        $quoteId = $this->cartRestoreCookie->getPending();
+        if (!$quoteId) {
+            return $result->setData(['restored' => false]);
+        }
+
+        $this->cartRestoreCookie->clearPending();
+
+        return $result->setData(['restored' => $this->cartRestorer->restore($quoteId)]);
+    }
+
+    public function createCsrfValidationException(RequestInterface $request): ?InvalidRequestException
+    {
+        return null;
+    }
+
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        return true;
+    }
+}

--- a/Model/Express/CartRestoreCookie.php
+++ b/Model/Express/CartRestoreCookie.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright 2026 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Vipps\Payment\Model\Express;
+
+use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
+use Magento\Framework\Stdlib\CookieManagerInterface;
+
+/**
+ * Reads and writes the cookies that drive Express cart restoration.
+ *
+ * The pending-quote cookie carries the cart's quote id from InitExpress to the restore entry points
+ * (the cart-page observer and the AJAX RestoreCart controller). The restored flag tells the storefront
+ * JS that a server-side restore already happened so it can refresh its cart state without restoring
+ * again. Cookie names are kept in sync with view/frontend/web/js/vipps-cart-restore.js.
+ */
+class CartRestoreCookie
+{
+    public const PENDING_COOKIE = 'vipps_pending_quote_id';
+    public const RESTORED_COOKIE = 'vipps_cart_restored';
+
+    private const PENDING_LIFETIME = 7200;
+    private const RESTORED_LIFETIME = 60;
+
+    public function __construct(
+        private readonly CookieManagerInterface $cookieManager,
+        private readonly CookieMetadataFactory $cookieMetadataFactory
+    ) {
+    }
+
+    public function setPending(int $quoteId): void
+    {
+        $metadata = $this->cookieMetadataFactory->createPublicCookieMetadata()
+            ->setDuration(self::PENDING_LIFETIME)
+            ->setPath('/');
+        $this->cookieManager->setPublicCookie(self::PENDING_COOKIE, (string)$quoteId, $metadata);
+    }
+
+    public function getPending(): int
+    {
+        return (int)$this->cookieManager->getCookie(self::PENDING_COOKIE);
+    }
+
+    public function clearPending(): void
+    {
+        $metadata = $this->cookieMetadataFactory->createPublicCookieMetadata()->setPath('/');
+        $this->cookieManager->deleteCookie(self::PENDING_COOKIE, $metadata);
+    }
+
+    public function markRestored(): void
+    {
+        $metadata = $this->cookieMetadataFactory->createPublicCookieMetadata()
+            ->setDuration(self::RESTORED_LIFETIME)
+            ->setPath('/');
+        $this->cookieManager->setPublicCookie(self::RESTORED_COOKIE, '1', $metadata);
+    }
+}

--- a/Model/Express/CartRestorer.php
+++ b/Model/Express/CartRestorer.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright 2026 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Vipps\Payment\Model\Express;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Vipps\Payment\Api\Data\QuoteStatusInterface;
+use Vipps\Payment\GatewayEpayment\Config\Config;
+use Vipps\Payment\Model\QuoteRepository;
+
+/**
+ * Restores a shopper's cart after an abandoned Vipps/MobilePay Express payment.
+ *
+ * Shared by both restore entry points: the server-side cart-page observer and the
+ * AJAX RestoreCart controller (which covers the bfcache back-button case).
+ */
+class CartRestorer
+{
+    public function __construct(
+        private readonly QuoteRepository $vippsQuoteRepository,
+        private readonly CartRepositoryInterface $cartRepository,
+        private readonly Session $checkoutSession,
+        private readonly ManagerInterface $messageManager,
+        private readonly Config $config
+    ) {
+    }
+
+    /**
+     * Cancel the pending Vipps monitoring quote and reactivate the cart quote.
+     *
+     * @param int $quoteId
+     * @return bool True if the cart was restored, false if there was nothing to restore
+     *              (e.g. the payment had already been processed).
+     */
+    public function restore(int $quoteId): bool
+    {
+        if (!$quoteId) {
+            return false;
+        }
+
+        try {
+            $vippsQuote = $this->vippsQuoteRepository->loadNewByQuote($quoteId);
+            $vippsQuote->setStatus(QuoteStatusInterface::STATUS_CANCELED);
+            $this->vippsQuoteRepository->save($vippsQuote);
+
+            /** @var Quote $quote */
+            $quote = $this->cartRepository->get($quoteId);
+            $quote->setIsActive(true);
+            $quote->setReservedOrderId(null);
+            $this->cartRepository->save($quote);
+            $this->checkoutSession->replaceQuote($quote);
+
+            $this->messageManager->addWarningMessage(
+                __('Your order was cancelled in %1.', $this->config->getTitle())
+            );
+
+            return true;
+        } catch (NoSuchEntityException $e) {
+            // Payment was already processed — nothing to restore.
+            return false;
+        }
+    }
+}

--- a/Observer/CartRestoreObserver.php
+++ b/Observer/CartRestoreObserver.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2026 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace Vipps\Payment\Observer;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Vipps\Payment\Model\Express\CartRestorer;
+use Vipps\Payment\Model\Express\CartRestoreCookie;
+
+class CartRestoreObserver implements ObserverInterface
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly CartRestoreCookie $cartRestoreCookie,
+        private readonly CartRestorer $cartRestorer
+    ) {
+    }
+
+    public function execute(Observer $observer): void
+    {
+        if ($this->request->getModuleName() !== 'checkout' || $this->request->getControllerName() !== 'cart') {
+            return;
+        }
+
+        $quoteId = $this->cartRestoreCookie->getPending();
+        if (!$quoteId) {
+            return;
+        }
+
+        $this->cartRestoreCookie->clearPending();
+
+        if ($this->cartRestorer->restore($quoteId)) {
+            $this->cartRestoreCookie->markRestored();
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "Vipps MobilePay Payment Module for Magento 2",
     "license": "proprietary",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "require": {
         "magento/framework": "101.0.*|103.0.*",
         "magento/module-sales": "101.0.*|103.0.*",

--- a/etc/frontend/sections.xml
+++ b/etc/frontend/sections.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2020 Vipps
+  ~ Copyright 2026 Vipps
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
   ~ documentation files (the "Software"), to deal in the Software without restriction, including without limitation
@@ -13,11 +13,9 @@
   ~ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   ~ IN THE SOFTWARE.
   -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="shortcut_buttons_container">
-        <observer name="vipps_express_checkout_shortcuts" instance="Vipps\Payment\Observer\AddVippsShortcutsObserver"/>
-    </event>
-    <event name="controller_action_predispatch">
-        <observer name="vipps_cart_restore" instance="Vipps\Payment\Observer\CartRestoreObserver"/>
-    </event>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
+    <action name="vipps/payment/restoreCart">
+        <section name="cart"/>
+    </action>
 </config>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -17,4 +17,11 @@
     <head>
         <css src="Vipps_Payment::css/vipps_styles.css"/>
     </head>
+    <body>
+        <referenceContainer name="before.body.end">
+            <block class="Magento\Framework\View\Element\Template"
+                   name="vipps.cart.restore"
+                   template="Vipps_Payment::cart-restore.phtml"/>
+        </referenceContainer>
+    </body>
 </page>

--- a/view/frontend/templates/cart-restore.phtml
+++ b/view/frontend/templates/cart-restore.phtml
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright 2026 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+/** @var \Magento\Framework\View\Element\Template $block */
+?>
+<script type="text/x-magento-init">
+{
+    "*": {
+        "Vipps_Payment/js/vipps-cart-restore": {
+            "restoreUrl": "<?= $block->escapeUrl($block->getUrl('vipps/payment/restoreCart')) ?>",
+            "cartUrl": "<?= $block->escapeUrl($block->getUrl('checkout/cart')) ?>",
+            "successUrl": "<?= $block->escapeUrl($block->getUrl('checkout/onepage/success')) ?>"
+        }
+    }
+}
+</script>

--- a/view/frontend/web/js/vipps-cart-restore.js
+++ b/view/frontend/web/js/vipps-cart-restore.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Vipps
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+define(['jquery', 'Magento_Customer/js/customer-data'], function ($, customerData) {
+    'use strict';
+
+    return function (config) {
+        var PENDING_COOKIE = 'vipps_pending_quote_id';
+        var RESTORED_COOKIE = 'vipps_cart_restored';
+
+        function getCookie(name) {
+            var match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+            return match ? decodeURIComponent(match[1]) : null;
+        }
+
+        function ajaxRestore() {
+            $.ajax({
+                url: config.restoreUrl,
+                type: 'POST',
+                dataType: 'json',
+                success: function (response) {
+                    if (response.restored) {
+                        customerData.reload(['cart'], false);
+                    }
+                }
+            });
+        }
+
+        if (window.location.href.indexOf(config.successUrl) !== -1) {
+            customerData.reload(['cart'], false);
+            return;
+        }
+
+        window.addEventListener('pageshow', function (event) {
+            if (event.persisted && getCookie(PENDING_COOKIE)) {
+                ajaxRestore();
+            }
+        });
+
+        // Observer ran server-side on the cart page — reload sections to sync JS state
+        if (getCookie(RESTORED_COOKIE)) {
+            document.cookie = RESTORED_COOKIE + '=; path=/; max-age=0';
+            customerData.reload(['cart', 'messages'], false);
+            return;
+        }
+
+        // Fresh load on any non-cart page: observer didn't run, AJAX restore
+        if (getCookie(PENDING_COOKIE)) {
+            ajaxRestore();
+        }
+    };
+});


### PR DESCRIPTION
## Problem
Pressing the browser back button after starting a Vipps/MobilePay Express payment could leave the cart empty — the shopper returns to an empty cart and has to re-add their items.

## Solution
`InitExpress` stores the pending quote id in a cookie when express payment is initiated. On return the cart is restored from it via a shared `Model/Express/CartRestorer` service (cancel the pending Vipps quote, reactivate the cart quote, replace it in the checkout session). Two complementary entry points drive it:

- a server-side observer on `controller_action_predispatch` for normal cart-page loads, and
- an AJAX `RestoreCart` controller invoked by `view/frontend/web/js/vipps-cart-restore.js` on `pageshow.persisted`, covering the browser bfcache back-button case (no server round-trip).

`Fallback` clears the cookie once the payment flow completes. Cookie handling (names + lifetimes) is centralised in `Model/Express/CartRestoreCookie`.

## Version
Bumps to **3.0.2** (CHANGELOG updated).

## Testing
Verified end-to-end on a live Magento 2.4.8 demo (Luma store view): add items → Checkout Express → browser back restores the cart, from both the product page and the cart page. The restore controller, observer, and JS path were also validated locally against a simulated post-initiate state (inactive quote + `new` vipps_quote + pending cookie).